### PR TITLE
Style dark code blocks

### DIFF
--- a/darkTheme.json
+++ b/darkTheme.json
@@ -22,5 +22,5 @@
   "errorTextColor": "#c7162b",
   "mentionHighlightBg": "#f99b11",
   "mentionHighlightLink": "#007AA6",
-  "codeTheme": "github"
+  "codeTheme": "github-dark"
 }


### PR DESCRIPTION
## Done
Updated the code theme on the dark theme to be the dark version of GitHub code.

## QA
- Go to https://chat.canonical.com/
- Hit the burger menu and select Account settings
- Go to Display > Theme
- Check Custom theme and paste the contents of this darkTheme.json in
- Open a DM with yourself or someone and type a code block
- See that it's background is dark

## Screenshot:

| Before  | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/1413534/85712454-3f59ca00-b6e0-11ea-8a98-4dcccbeb0c85.png)  | ![image](https://user-images.githubusercontent.com/1413534/85712359-281adc80-b6e0-11ea-8012-988acd8457c4.png)  |

Fixes https://github.com/canonical-web-and-design/canonical-mattermost-themes/issues/1
Fixes https://bugs.launchpad.net/canonical-mattermost/+bug/1884978