### PR TITLE
Update dark link color

### DIFF
--- a/darkTheme.json
+++ b/darkTheme.json
@@ -16,7 +16,7 @@
   "centerChannelBg": "#333333",
   "centerChannelColor": "#ffffff",
   "newMessageSeparator": "#335280",
-  "linkColor": "#007aa6",
+  "linkColor": "#8FC7FF",
   "buttonBg": "#0e8420",
   "buttonColor": "#ffffff",
   "errorTextColor": "#c7162b",


### PR DESCRIPTION
## Done
- Updated the dark link color to something more visible

## QA
- Go to https://chat.canonical.com/
- Hit the burger menu and select Account settings
- Go to Display > Theme
- Check Custom theme and paste the contents of this darkTheme.json in
- Check links are more legible

Fixes https://github.com/canonical-web-and-design/canonical-mattermost-themes/issues/5