### PR TITLE
Update the mention color on dark theme

### DIFF
--- a/darkTheme.json
+++ b/darkTheme.json
@@ -12,7 +12,7 @@
   "dndIndicator": "#c7162b",
   "mentionBg": "#335280",
   "mentionBj": "#335280",
-  "mentionColor": "#007aa6",
+  "mentionColor": "#ffffff",
   "centerChannelBg": "#333333",
   "centerChannelColor": "#ffffff",
   "newMessageSeparator": "#335280",


### PR DESCRIPTION
## Done
Update the mention color on dark theme

## QA
- Go to https://chat.canonical.com/
- Hit the burger menu and select Account settings
- Go to Display > Theme
- Check Custom theme and paste the contents of this darkTheme.json in
- See that the mention indicator in the sidenav is now legible.

## Screenshot:

| Before  | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/1413534/87044463-72c34b00-c1ee-11ea-98d7-a1852e8041f1.png) | ![image](https://user-images.githubusercontent.com/1413534/87044380-56bfa980-c1ee-11ea-9b30-9003e950058e.png) |

Fixes https://github.com/canonical-web-and-design/canonical-mattermost-themes/issues/6